### PR TITLE
Fixing the exception handling action Try()

### DIFF
--- a/core/src/main/scala/com/tribbloids/spookystuff/actions/Block.scala
+++ b/core/src/main/scala/com/tribbloids/spookystuff/actions/Block.scala
@@ -85,8 +85,10 @@ final case class Try(
     }
     catch {
       case e: Throwable =>
-        if (taskContext.attemptNumber() < retries) throw e
-        else LoggerFactory.getLogger(this.getClass).info("Aborted on exception: " + e)
+        if (taskContext.attemptNumber() > retries) {
+          LoggerFactory.getLogger(this.getClass).info("Aborted on exception: " + e)
+          throw e
+        }
     }
 
     pages


### PR DESCRIPTION
It appears that Try() was previously doing the opposite of it's intended purpose, so this fixes it. The previous logic would always throw an exception, even if the current attempt number was less than the number of retries allocated to the action. 