### PR TITLE
Fix for new Try() causing fatal exceptions on first error

### DIFF
--- a/core/src/main/scala/com/tribbloids/spookystuff/actions/Block.scala
+++ b/core/src/main/scala/com/tribbloids/spookystuff/actions/Block.scala
@@ -102,15 +102,17 @@ final case class Try(
         val logger = LoggerFactory.getLogger(this.getClass)
         val timesLeft = retries - taskContext.attemptNumber()
         if (timesLeft > 0) {
-          throw new TryException(
+          logger.warn(
             s"Retrying cluster-wise on ${e.getClass.getSimpleName}... $timesLeft time(s) left\n" +
               "(if Spark job failed because of this, please increase your spark.task.maxFailures)" +
               this.getActionExceptionMessage(session),
             e
           )
         }
-        else logger.warn(s"Failover on ${e.getClass.getSimpleName}: Cluster-wise retries has depleted... ")
-        logger.info("\t\\-->", e)
+        else {
+          logger.info("\t\\-->", e)
+          throw new TryException(s"Failover on ${e.getClass.getSimpleName}: Cluster-wise retries has depleted... ")
+        }
     }
 
     pages


### PR DESCRIPTION
While I could accept that I'm possibly overlooking something again, I believe logger.warn() and TryException() were mixed up here, as how it was previously written was causing a fatal exception to be thrown any time that timesLeft was greater than 0, which includes the very first time an Action is attempted. I have tested this and instead of getting fatal errors that claim the Action will be retried 10 more times, I now can complete a crawl of URLs without the program crashing.