### PR TITLE
Adding a new TryLocally() wrapper for actions.

### DIFF
--- a/core/src/main/scala/com/tribbloids/spookystuff/actions/Block.scala
+++ b/core/src/main/scala/com/tribbloids/spookystuff/actions/Block.scala
@@ -160,7 +160,7 @@ final case class TryLocally(
     }
     catch {
       case e: Throwable =>
-        retry[Seq[Page]](retries - 1)({
+        retry[Seq[Page]](retries)({
           val pages = new ArrayBuffer[Page]()
 
           for (action <- self) {


### PR DESCRIPTION
`TryLocally(trace: Set[actions.trace], retries: Int)` continues to retry **trace** (a set of actions) until it has reached the number of iterations specified by **retries**, at which point it will throw the exception rather than retry.