### PR TITLE
Fixes the problem with conf.dirs on Databricks

### DIFF
--- a/core/src/main/scala/com/tribbloids/spookystuff/SpookyConf.scala
+++ b/core/src/main/scala/com/tribbloids/spookystuff/SpookyConf.scala
@@ -127,26 +127,8 @@ class SpookyConf (
 
   def importFrom(implicit sparkConf: SparkConf): SpookyConf = {
 
-    val root = Option(this.dirs.root).getOrElse(SpookyConf.getDefault("spooky.dirs.root", "temp"))
-    //    def root_/(subdir: String) = Utils.uriSlash(root) + subdir
-
-    val localRoot = Option(this.dirs.root).getOrElse(SpookyConf.getDefault("spooky.dirs.root.local", "temp"))
-    //    def localRoot_/(subdir: String) = Utils.uriSlash(root) + subdir
-
-    val dirs = new DirConf(
-      root,
-      localRoot,
-      Option(this.dirs._autoSave).getOrElse(SpookyConf.getDefault("spooky.dirs.autosave")),
-      Option(this.dirs._cache).getOrElse(SpookyConf.getDefault("spooky.dirs.cache")),
-      Option(this.dirs._errorDump).getOrElse(SpookyConf.getDefault("spooky.dirs.error.dump")),
-      Option(this.dirs._errorScreenshot).getOrElse(SpookyConf.getDefault("spooky.dirs.error.screenshot")),
-      Option(this.dirs._checkpoint).getOrElse(SpookyConf.getDefault("spooky.dirs.checkpoint")),
-      Option(this.dirs._errorDumpLocal).getOrElse(SpookyConf.getDefault("spooky.dirs.error.dump.local")),
-      Option(this.dirs._errorScreenshotLocal).getOrElse(SpookyConf.getDefault("spooky.dirs.error.screenshot.local"))
-    )
-
     new SpookyConf(
-      dirs,
+      this.dirs,
 
       this.shareMetrics,
 

--- a/core/src/test/scala/com/tribbloids/spookystuff/TestSpookyContext.scala
+++ b/core/src/test/scala/com/tribbloids/spookystuff/TestSpookyContext.scala
@@ -12,6 +12,7 @@ class TestSpookyContext extends SpookyEnvSuite{
 
     val spooky = this.spooky
     spooky.conf.shareMetrics = false
+    spooky.conf.dirs.cache = "dog"
 
     val rdd2 = spooky.create(Seq("dummy"))
     assert(!(rdd2.spooky eq spooky))


### PR DESCRIPTION
Perhaps I am overlooking something, but it would seem that we should just be able to use the current SpookyConf.dirs property as the defaults would already have been set if not specified explicitly to begin with. The example test case also passes using this approach.